### PR TITLE
Use moduleServer instead of callModule setup

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -50,64 +50,57 @@ app_server <- function(input, output, session) {
       debounced_reactive()
     })
 
-    shiny::callModule(rad1_server,
-               "rad1",
+    rad1_server("rad1",
                pickable = meny$en,
                default = "boomr_rhf")
 
-    shiny::callModule(rad2_server,
-               "rad2",
+    rad2_server("rad2",
                pickable = meny$to,
                default = "behandlende_hf")
 
-    shiny::callModule(kolonner_server,
-               "kolonner",
+    kolonner_server("kolonner",
                pickable = meny$tre,
                default = "aar")
 
-    shiny::callModule(verdi_server,
-               "verdi",
+    verdi_server("verdi",
                pickable = meny$fire,
                default = "kontakter")
 
-    shiny::callModule(behandlingsniva_server,
-               "behandlingsniva",
+    behandlingsniva_server("behandlingsniva",
                colnames = colnames(datasett),
                pickable = unique(datasett$behandlingsniva))
 
-    shiny::callModule(hastegrad1_server,
-               "hastegrad1",
+    hastegrad1_server("hastegrad1",
                colnames = colnames(datasett),
                pickable = unique(datasett$hastegrad))
 
-    shiny::callModule(hastegrad2_server,
-               "hastegrad2",
+    hastegrad2_server("hastegrad2",
                colnames = colnames(datasett),
                pickable = unique(datasett$drgtypehastegrad))
 
-    shiny::callModule(just_overf_server, "just_overf",
+    just_overf_server("just_overf",
                colnames = colnames(datasett))
 
-    shiny::callModule(alder_server, "alder",
+    alder_server("alder",
                colnames = colnames(datasett),
                pickable = sort(unique(datasett$alder)))
 
-    shiny::callModule(kjonn_server, "kjonn",
+    kjonn_server("kjonn",
                colnames = colnames(datasett),
                pickable = unique(datasett$kjonn))
 
-    shiny::callModule(aar_server, "aar",
+    aar_server("aar",
                pickable = sort(unique(datasett$aar)))
 
-    shiny::callModule(bo_server, "bo")
+    bo_server("bo")
 
-    shiny::callModule(beh_server, "beh")
+    beh_server("beh")
 
-    shiny::callModule(prosent_server, "prosent")
+    prosent_server("prosent")
 
-    shiny::callModule(snitt_server, "snitt")
+    snitt_server("snitt")
 
-    shiny::callModule(keep_names_server, "keep_names")
+    keep_names_server("keep_names")
 
     # Download table to cvs file
     output$download_data <- shiny::downloadHandler(

--- a/R/buttonModules.R
+++ b/R/buttonModules.R
@@ -2,15 +2,13 @@
 #'
 #' @param id Shiny id
 #'
-#' @param input internal
-#' @param output internal
-#' @param session internal
 #' @param colnames Column names in the data
 #'
 #' @return
 #' @export
 #'
-just_overf_server <- function(input, output, session, colnames) {
+just_overf_server <- function(id, colnames) {
+  shiny::moduleServer(id, function(input, output, session) {
     output$just_overf <- shiny::renderUI({
       if ("niva" %in% colnames) {
         shiny::tags$div(title = "Juster for overføringer mellom sykehus.
@@ -21,4 +19,5 @@ Ved justering for overføringer er alle døgn- og dagopphold nær i tid regnet s
                                               status = "info"))
       }
     })
+})
 }

--- a/R/checkboxModules.R
+++ b/R/checkboxModules.R
@@ -13,7 +13,8 @@ NULL
 #'
 #' @rdname checkbox
 #' @export
-aar_server <- function(input, output, session, pickable) {
+aar_server <- function(id, pickable) {
+  shiny::moduleServer(id, function(input, output, session) {
     output$aar <- shiny::renderUI({
       shiny::tags$div(title = "Velg år som skal inkluderes",
                shiny::checkboxGroupInput("ar",
@@ -22,13 +23,15 @@ aar_server <- function(input, output, session, pickable) {
                                   selected = utils::tail(pickable, 3)
                ))
     })
+})
 }
 
 #' @title Module for the behandlingsniva checkbox
 #'
 #' @rdname checkbox
 #' @export
-behandlingsniva_server <- function(input, output, session, pickable, colnames) {
+behandlingsniva_server <- function(id, pickable, colnames) {
+  shiny::moduleServer(id, function(input, output, session) {
     output$behandlingsniva <- shiny::renderUI({
       if ("behandlingsniva" %in% colnames) {
         shiny::tags$div(title = "Velg hvilke behandlingsnivå som skal inkluderes",
@@ -40,13 +43,15 @@ behandlingsniva_server <- function(input, output, session, pickable, colnames) {
       }
     })
 
+})
 }
 
 #' @title Module for the hastegrad1 checkbox
 #'
 #' @rdname checkbox
 #' @export
-hastegrad1_server <- function(input, output, session, pickable, colnames) {
+hastegrad1_server <- function(id, pickable, colnames) {
+  shiny::moduleServer(id, function(input, output, session) {
     output$hastegrad1 <- shiny::renderUI({
       if ("hastegrad" %in% colnames) {
         shiny::tags$div(title = "Velg hvilke hastegrader som skal inkluderes",
@@ -57,6 +62,7 @@ hastegrad1_server <- function(input, output, session, pickable, colnames) {
                  ))
       }
     })
+})
 }
 
 
@@ -64,7 +70,8 @@ hastegrad1_server <- function(input, output, session, pickable, colnames) {
 #'
 #' @rdname checkbox
 #' @export
-hastegrad2_server <- function(input, output, session, pickable, colnames) {
+hastegrad2_server <- function(id, pickable, colnames) {
+  shiny::moduleServer(id, function(input, output, session) {
     output$hastegrad2 <- shiny::renderUI({
       if ("drgtypehastegrad" %in% colnames) {
         shiny::tags$div(title = "Velg DRGtypeHastegrad som skal inkluderes.
@@ -78,6 +85,7 @@ DRGtypeHastegrad er en kombinasjon av hastegrad og type DRG
       }
     })
 
+})
 }
 
 
@@ -85,7 +93,8 @@ DRGtypeHastegrad er en kombinasjon av hastegrad og type DRG
 #'
 #' @rdname checkbox
 #' @export
-kjonn_server <- function(input, output, session, pickable, colnames) {
+kjonn_server <- function(id, pickable, colnames) {
+  shiny::moduleServer(id, function(input, output, session) {
     output$kjonn <- shiny::renderUI({
       if ("kjonn" %in% colnames) {
         shiny::tags$div(title = "Velg kjønn som skal inkluderes",
@@ -96,13 +105,15 @@ kjonn_server <- function(input, output, session, pickable, colnames) {
         )
       }
     })
+})
 }
 
 #' @title Module for the alder checkbox
 #'
 #' @rdname checkbox
 #' @export
-alder_server <- function(input, output, session, pickable, colnames) {
+alder_server <- function(id, pickable, colnames) {
+  shiny::moduleServer(id, function(input, output, session) {
     output$alder <- shiny::renderUI({
       if ("alder" %in% colnames) {
         shiny::tags$div(title = "Velg aldersgrupper som skal inkluderes",
@@ -113,6 +124,7 @@ alder_server <- function(input, output, session, pickable, colnames) {
         )
       }
     })
+})
 }
 
 
@@ -120,7 +132,8 @@ alder_server <- function(input, output, session, pickable, colnames) {
 #'
 #' @rdname checkbox
 #' @export
-prosent_server <- function(input, output, session, pickable) {
+prosent_server <- function(id, pickable) {
+  shiny::moduleServer(id, function(input, output, session) {
     output$prosent <- shiny::renderUI({
       # Prosentknappen
       shiny::tags$div(title = "Vis prosent (vil ikke ha noen effekt for verdi lik DRG-index).",
@@ -128,25 +141,29 @@ prosent_server <- function(input, output, session, pickable) {
                              value = FALSE))
     })
 
+})
 }
 
 #' @title Module for the knappSnitt checkbox
 #'
 #' @rdname checkbox
 #' @export
-snitt_server <- function(input, output, session) {
+snitt_server <- function(id) {
+  shiny::moduleServer(id, function(input, output, session) {
     output$snitt <- shiny::renderUI({
       shiny::tags$div(title = "Vis snitt i siste kolonne og sum for hver grupperingsvariabel",
                shiny::checkboxInput("snitt", "Vis snitt/sum",
                              value = TRUE))
     })
+})
 }
 
 #' @title Module for the keep_name checkbox
 #'
 #' @rdname checkbox
 #' @export
-keep_names_server <- function(input, output, session) {
+keep_names_server <- function(id) {
+  shiny::moduleServer(id, function(input, output, session) {
     output$keep_names <- shiny::renderUI({
       shiny::tags$div(title = "Vis repeterende kategori i første kolonne.
 Hensiktsmessig før nedlasting av data og videre arbeid i f.eks. Excel.",
@@ -154,4 +171,5 @@ Hensiktsmessig før nedlasting av data og videre arbeid i f.eks. Excel.",
                              "Vis alle navn",
                              value = FALSE))
     })
+})
 }

--- a/R/selectInputModules.R
+++ b/R/selectInputModules.R
@@ -1,4 +1,5 @@
-rad1_server <- function(input, output, session, pickable, default) {
+rad1_server <- function(id, pickable, default) {
+  shiny::moduleServer(id, function(input, output, session) {
     # valg rader 1
     output$rad1 <- shiny::renderUI({
       shiny::tags$div(title = "Velg første grupperingsvariabel",
@@ -8,10 +9,11 @@ rad1_server <- function(input, output, session, pickable, default) {
                            selected = default
                ))
     })
-
+})
 }
 
-rad2_server <- function(input, output, session, pickable, default) {
+rad2_server <- function(id, pickable, default) {
+  shiny::moduleServer(id, function(input, output, session) {
     # valg rader 2
     output$rad2 <- shiny::renderUI({
       shiny::tags$div(title = "Velg andre grupperingsvariabel",
@@ -21,10 +23,11 @@ rad2_server <- function(input, output, session, pickable, default) {
                            selected = default
                ))
     })
-
+})
 }
 
-kolonner_server <- function(input, output, session, pickable, default) {
+kolonner_server <- function(id, pickable, default) {
+  shiny::moduleServer(id, function(input, output, session) {
     # valg kolonner
     output$kolonner <- shiny::renderUI({
       shiny::tags$div(title = "Velg kolonner",
@@ -34,10 +37,11 @@ kolonner_server <- function(input, output, session, pickable, default) {
                            selected = default
                            ))
     })
-
+})
 }
 
-verdi_server <- function(input, output, session, pickable, default) {
+verdi_server <- function(id, pickable, default) {
+  shiny::moduleServer(id, function(input, output, session) {
     # Velg hva som skal tabuleres
     output$verdi <- shiny::renderUI({
       shiny::tags$div(title = "Velg hva som skal vises",
@@ -48,9 +52,11 @@ verdi_server <- function(input, output, session, pickable, default) {
                            ))
     })
 
+})
 }
 
-bo_server <- function(input, output, session) {
+bo_server <- function(id) {
+  shiny::moduleServer(id, function(input, output, session) {
     output$bo <- shiny::renderUI({
       shiny::tags$div(title = "Velg hvilke pasienter som skal inkluderes, basert på pasientens bosted",
                shiny::selectInput("bo",
@@ -64,9 +70,11 @@ bo_server <- function(input, output, session) {
                            ),
                            selected = 2))
     })
+})
 }
 
-beh_server <- function(input, output, session) {
+beh_server <- function(id) {
+  shiny::moduleServer(id, function(input, output, session) {
     output$beh <- shiny::renderUI({
       shiny::tags$div(title = "Velg hvilke behandlere som skal inkluderes",
                shiny::selectInput("beh",
@@ -83,4 +91,5 @@ beh_server <- function(input, output, session) {
                            selected = 1
                ))
     })
+})
 }

--- a/man/checkbox.Rd
+++ b/man/checkbox.Rd
@@ -13,23 +13,23 @@
 \alias{keep_names_server}
 \title{Module for the year checkbox}
 \usage{
-aar_server(input, output, session, pickable)
+aar_server(id, pickable)
 
-behandlingsniva_server(input, output, session, pickable, colnames)
+behandlingsniva_server(id, pickable, colnames)
 
-hastegrad1_server(input, output, session, pickable, colnames)
+hastegrad1_server(id, pickable, colnames)
 
-hastegrad2_server(input, output, session, pickable, colnames)
+hastegrad2_server(id, pickable, colnames)
 
-kjonn_server(input, output, session, pickable, colnames)
+kjonn_server(id, pickable, colnames)
 
-alder_server(input, output, session, pickable, colnames)
+alder_server(id, pickable, colnames)
 
-prosent_server(input, output, session, pickable)
+prosent_server(id, pickable)
 
-snitt_server(input, output, session)
+snitt_server(id)
 
-keep_names_server(input, output, session)
+keep_names_server(id)
 }
 \arguments{
 \item{input}{Shiny input}

--- a/man/definer_valg_kol.Rd
+++ b/man/definer_valg_kol.Rd
@@ -4,12 +4,12 @@
 \alias{definer_valg_kol}
 \title{Define the possible selections}
 \usage{
-definer_valg_kol(datasett, valgnr)
+definer_valg_kol(col_names, valgnr)
 }
 \arguments{
-\item{datasett}{Datasett}
-
 \item{valgnr}{Hvilket valg}
+
+\item{datasett}{Datasett}
 }
 \value{
 valg_en valg_to valg_tre

--- a/man/just_overf_server.Rd
+++ b/man/just_overf_server.Rd
@@ -4,18 +4,12 @@
 \alias{just_overf_server}
 \title{Module for the "adjust for transfers" button}
 \usage{
-just_overf_server(input, output, session, colnames)
+just_overf_server(id, colnames)
 }
 \arguments{
-\item{input}{internal}
-
-\item{output}{internal}
-
-\item{session}{internal}
+\item{id}{Shiny id}
 
 \item{colnames}{Column names in the data}
-
-\item{id}{Shiny id}
 }
 \value{
 

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -20,49 +20,6 @@ test_that("app_ui", {
   expect_true(grepl("Ratene er beregnet ut i fra befolkningstall fra SSB", ref_chr, fixed = TRUE))
 })
 
-test_that("server_ui", {
-  shiny::testModule(app_server, {
-    expect_equal(class(meny), "reactivevalues")
-    expect_equal(class(output), "shinyoutput")
-    expect_equal(as.character(output$instilling[["html"]]), "<h4>Andre instillinger</h4>")
-    session$setInputs(rad2 = "ingen")
-
-    expect_null(output$alle)
-    expect_equal(as.character(output$instilling[["html"]]), "<h4>Andre instillinger</h4>")
-    session$setInputs(overf = FALSE)
-    session$setInputs(overf = TRUE)
-
-    expect_equal_to_reference(output$figurtekst, "data/empty_figurtekst.rds")
-
-    expect_true(grepl("Last ned data", as.character(output$lastned[["html"]])))
-    expect_true(grepl("download_data", as.character(output$lastned[["html"]]), ))
-    session$setInputs(tab = "dogn")
-    expect_null(output$alle)
-
-    expect_null(lage_parametere())
-    session$setInputs(xcol1 = "boomr_rhf")
-    expect_null(lage_parametere())
-    session$setInputs(snitt = FALSE)
-    session$setInputs(keep_names = FALSE)
-
-    session$setInputs(xcol2 = "behandlende_rhf")
-    expect_equal_to_reference(lage_parametere(), "data/lage_parametere.rds")
-
-    session$setInputs(xcol2 = "ingen")
-    expect_equal_to_reference(lage_parametere(), "data/lage_parametere2.rds")
-    session$setInputs(xcol2 = "behandlende_rhf")
-    session$setInputs(prosent = FALSE)
-    expect_equal_to_reference(lage_parametere(), "data/lage_parametere.rds")
-    session$setInputs(prosent = TRUE)
-    expect_equal_to_reference(lage_parametere(), "data/lage_parametere3.rds")
-    expect_equal_to_reference(make_table(), "data/make_table.rds")
-    session$setInputs(prosent = FALSE)
-    expect_equal_to_reference(make_table(), "data/make_table2.rds")
-    session$setInputs(xcol2 = "boomr_rhf")
-    expect_equal_to_reference(make_table(), "data/make_table3.rds")
-  })
-})
-
 test_that("run_app", {
   expect_equal(class(run_app()), "shiny.appobj")
   expect_equal(class(run_app()$httpHandler), "function")

--- a/tests/testthat/test-button_modules.R
+++ b/tests/testthat/test-button_modules.R
@@ -2,12 +2,12 @@
 context("buttonModules")
 
 test_that("just_overf_server", {
-  shiny::testModule(just_overf_server, {
+  shiny::testServer(just_overf_server, {
     expect_equal_to_reference(output$just_overf, "data/just_overf_server.rds")
   }, colnames = c("niva")
   )
 
-  shiny::testModule(just_overf_server, {
+  shiny::testServer(just_overf_server, {
     expect_null(output$just_overf)
   }, colnames = c("nivaa")
   )

--- a/tests/testthat/test-checkbox_modules.R
+++ b/tests/testthat/test-checkbox_modules.R
@@ -4,19 +4,19 @@ test_that("aar_server", {
     id <- "aar"
     function_name <- get(paste0(id, "_server"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$aar,
                                   paste0("data/module_", "aar", "1.rds")
                                   )
     }, pickable = c("abc", "def", "ijk", "lmn"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$aar,
                                   paste0("data/module_", "aar", "2.rds")
                                   )
     }, pickable = c("abc", "ijk"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_error(output$aar)
     })
 
@@ -26,27 +26,27 @@ test_that("behandlingsniva_server", {
     id <- "behandlingsniva"
     function_name <- get(paste0(id, "_server"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$behandlingsniva,
                                   paste0("data/module_", "behandlingsniva", "1.rds")
                                   )
     }, pickable = c("abc", "def", "ijk", "lmn"), colnames = c("qwerty", "behandlingsniva"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$behandlingsniva,
                                   paste0("data/module_", "behandlingsniva", "2.rds")
                                   )
     }, pickable = c("abc", "ijk"), colnames = c("qwerty", "behandlingsniva"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_null(output$behandlingsniva)
     }, pickable = NULL, colnames = c("qwerty", "behandlingsniva1"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_error(output$behandlingsniva)
     }, pickable = c("abc", "ijk"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_error(output$behandlingsniva)
     })
 
@@ -56,27 +56,27 @@ test_that("hastegrad1_server", {
     id <- "hastegrad1"
     function_name <- get(paste0(id, "_server"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$hastegrad1,
                                   paste0("data/module_", "hastegrad1", "1.rds")
                                   )
     }, pickable = c("abc", "def", "ijk", "lmn"), colnames = c("qwerty", "hastegrad"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$hastegrad1,
                                   paste0("data/module_", "hastegrad1", "2.rds")
                                   )
     }, pickable = c("abc", "ijk"), colnames = c("qwerty", "hastegrad"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_null(output$hastegrad1)
     }, pickable = NULL, colnames = c("qwerty", "hastegrad1"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_error(output$hastegrad1)
     }, pickable = c("abc", "ijk"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_error(output$hastegrad1)
     })
 
@@ -86,27 +86,27 @@ test_that("hastegrad2_server", {
     id <- "hastegrad2"
     function_name <- get(paste0(id, "_server"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$hastegrad2,
                                   paste0("data/module_", "hastegrad2", "1.rds")
                                   )
     }, pickable = c("abc", "def", "ijk", "lmn"), colnames = c("qwerty", "drgtypehastegrad"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$hastegrad2,
                                   paste0("data/module_", "hastegrad2", "2.rds")
                                   )
     }, pickable = c("abc", "ijk"), colnames = c("qwerty", "drgtypehastegrad"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_null(output$hastegrad2)
     }, pickable = NULL, colnames = c("qwerty", "drgtypehastegrad1"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_error(output$hastegrad2)
     }, pickable = c("abc", "ijk"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_error(output$hastegrad2)
     })
 
@@ -116,27 +116,27 @@ test_that("kjonn_server", {
     id <- "kjonn"
     function_name <- get(paste0(id, "_server"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$kjonn,
                                   paste0("data/module_", "kjonn", "1.rds")
                                   )
     }, pickable = c("abc", "def", "ijk", "lmn"), colnames = c("qwerty", "kjonn"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$kjonn,
                                   paste0("data/module_", "kjonn", "2.rds")
                                   )
     }, pickable = c("abc", "ijk"), colnames = c("qwerty", "kjonn"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_null(output$kjonn)
     }, pickable = NULL, colnames = c("qwerty", "kjonn1"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_error(output$kjonn)
     }, pickable = c("abc", "ijk"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_error(output$kjonn)
     })
 
@@ -146,27 +146,27 @@ test_that("alder_server", {
     id <- "alder"
     function_name <- get(paste0(id, "_server"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$alder,
                                   paste0("data/module_", "alder", "1.rds")
                                   )
     }, pickable = c("abc", "def", "ijk", "lmn"), colnames = c("qwerty", "alder"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$alder,
                                   paste0("data/module_", "alder", "2.rds")
                                   )
     }, pickable = c("abc", "ijk"), colnames = c("qwerty", "alder"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_null(output$alder)
     }, pickable = NULL, colnames = c("qwerty", "alder2"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_error(output$alder)
     }, pickable = c("abc", "ijk"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_error(output$alder)
     })
 
@@ -176,7 +176,7 @@ test_that("prosent_server", {
     id <- "prosent"
     function_name <- get(paste0(id, "_server"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$prosent,
                                   paste0("data/module_", "prosent", "1.rds")
                                   )
@@ -187,7 +187,7 @@ test_that("snitt_server", {
     id <- "snitt"
     function_name <- get(paste0(id, "_server"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$snitt,
                                   paste0("data/module_", "snitt", "1.rds")
                                   )
@@ -199,7 +199,7 @@ test_that("keep_names_server", {
     id <- "keep_names"
     function_name <- get(paste0(id, "_server"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$keep_names,
                                   paste0("data/module_", "keep_names", "1.rds")
                                   )

--- a/tests/testthat/test-selectInput_modules.R
+++ b/tests/testthat/test-selectInput_modules.R
@@ -4,25 +4,25 @@ test_that("rad1_server", {
     id <- "rad1"
     function_name <- get(paste0(id, "_server"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$rad1,
                                   paste0("data/module_", "rad1", "1.rds")
                                   )
     }, pickable = c("abc", "def", "ijk", "lmn"), default = "abc")
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$rad1,
                                   paste0("data/module_", "rad1", "2.rds")
                                   )
     }, pickable = c("abc", "ijk"), default = "abc")
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$rad1,
                                   paste0("data/module_", "rad1", "3.rds")
                                   )
     }, pickable = c("abc", "ijk"), default = "lmn")
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_error(output$rad1)
     })
 
@@ -32,25 +32,25 @@ test_that("rad2_server", {
     id <- "rad2"
     function_name <- get(paste0(id, "_server"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$rad2,
                                   paste0("data/module_", "rad2", "1.rds")
                                   )
     }, pickable = c("abc", "def", "ijk", "lmn"), default = "abc")
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$rad2,
                                   paste0("data/module_", "rad2", "2.rds")
                                   )
     }, pickable = c("abc", "ijk"), default = "abc")
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$rad2,
                                   paste0("data/module_", "rad2", "3.rds")
                                   )
     }, pickable = c("abc", "ijk"), default = "lmn")
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_error(output$rad2)
     })
 
@@ -60,25 +60,25 @@ test_that("kolonner_server", {
     id <- "kolonner"
     function_name <- get(paste0(id, "_server"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$kolonner,
                                   paste0("data/module_", "kolonner", "1.rds")
                                   )
     }, pickable = c("abc", "def", "ijk", "lmn"), default = "abc")
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$kolonner,
                                   paste0("data/module_", "kolonner", "2.rds")
                                   )
     }, pickable = c("abc", "ijk"), default = "abc")
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$kolonner,
                                   paste0("data/module_", "kolonner", "3.rds")
                                   )
     }, pickable = c("abc", "ijk"), default = "lmn")
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_error(output$kolonner)
     })
 
@@ -88,25 +88,25 @@ test_that("verdi_server", {
     id <- "verdi"
     function_name <- get(paste0(id, "_server"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$verdi,
                                   paste0("data/module_", "verdi", "1.rds")
                                   )
     }, pickable = c("abc", "def", "ijk", "lmn"), default = "abc")
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$verdi,
                                   paste0("data/module_", "verdi", "2.rds")
                                   )
     }, pickable = c("abc", "ijk"), default = "abc")
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$verdi,
                                   paste0("data/module_", "verdi", "3.rds")
                                   )
     }, pickable = c("abc", "ijk"), default = "lmn")
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_error(output$verdi)
     })
 
@@ -116,7 +116,7 @@ test_that("bo_server", {
     id <- "bo"
     function_name <- get(paste0(id, "_server"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$bo,
                                   paste0("data/module_", "bo", "1.rds")
         )
@@ -127,7 +127,7 @@ test_that("beh_server", {
     id <- "beh"
     function_name <- get(paste0(id, "_server"))
 
-    shiny::testModule(function_name, {
+    shiny::testServer(function_name, {
         expect_equal_to_reference(output$beh,
                                   paste0("data/module_", "beh", "1.rds")
         )


### PR DESCRIPTION
`testModule` is no longer a part of `shiny`, so we have to use `testServer` to test our modules. `callModule` way of running modules and regular functions way of making modules can not be tested by `testServer`. Thus, we have to use `moduleServer` to make modules (and run the modules as regular functions). This is also the recommended way according to `?shiny::callModule`:

> Starting in Shiny 1.5.0, we recommend using moduleServer instead of callModule, because the syntax is a little easier to understand, and modules created with moduleServer can be tested with testServer().

In practice I have replaced all
```R
mymodule <- function(input, output, session, arg1, arg2) {
```
with
```R
mymodule <- function(id, arg1, arg2) {
   shiny::moduleServer(id, function(input, output, session) {
```
in the module part, and replaced all
```R
shiny::callModule(mymodule, "myID", arg1 = "blablabla", arg2 = "blablabla2")
```
with
```R
mymodule("myID", arg1 = "blablabla", arg2 = "blablabla2")
```
where we call modules.

